### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
 		"@types/node": "^25.6.0",
 		"npm-run-all2": "^8.0.4"
 	},
-	"packageManager": "pnpm@10.33.4"
+	"packageManager": "pnpm@11.0.9"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ packages:
   - tools/*
 patchedDependencies:
   storybook-addon-tag-badges: patches/storybook-addon-tag-badges.patch
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - esbuild
+  - fsevents


### PR DESCRIPTION
Upgrades pnpm from 10 to 11 and adds `onlyBuiltDependencies` to allow build scripts for `@parcel/watcher`, `esbuild`, and `fsevents` (required by pnpm 11's stricter build script policy).

Closes #643