### PR TITLE
feat: add experiment badge (🔬)

### DIFF
--- a/.changeset/add-experiment-badge.md
+++ b/.changeset/add-experiment-badge.md
@@ -1,0 +1,5 @@
+---
+"@repobuddy/storybook": minor
+---
+
+Add `experiment` tag and `experimentBadge` (🔬) for stories covering features in early-stage experimentation.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,7 +9,17 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["!node_modules", "!**/.sb-themes", "!dist", "!build", "!coverage", "!*.mdx", "!*.md", "!.vscode"]
+		"includes": [
+			"!node_modules",
+			"!**/.sb-themes",
+			"!dist",
+			"!build",
+			"!coverage",
+			"!*.mdx",
+			"!*.md",
+			"!.vscode",
+			"!.claude"
+		]
 	},
 	"formatter": {
 		"enabled": true,

--- a/libs/storybook/readme.md
+++ b/libs/storybook/readme.md
@@ -81,6 +81,7 @@ we provide a different set of badges that uses emojis (order: first match wins):
 | Badge   | Tag                                                      | Description                                                                               |
 | :-----  | :------------------------------------------------------- | :---------------------------------------------------------------------------------------- |
 | 🆕      | `new`                                                    | Recently added stories                                                                    |
+| 🔬      | `experiment`                                             | Features in experiment                                                                    |
 | 🔴      | `alpha`                                                  | Features in alpha                                                                         |
 | 🟡      | `beta`                                                   | Features in beta                                                                          |
 | 🔵      | `rc`                                                     | Release candidate                                                                         |

--- a/libs/storybook/src/storybook-addon-tag-badges/experiment_badge.mdx
+++ b/libs/storybook/src/storybook-addon-tag-badges/experiment_badge.mdx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="storybook-addon-tag-badges/experimentBadge" />
+
+# Experiment badge
+
+Use the **experiment** badge to mark a component or prop as an early-stage experiment that may change significantly. The badge displays 🔬 with an "Experiment" tooltip.
+
+## Usage
+
+Add the `experiment` tag to your story.
+
+```tsx
+export const YourStory = {
+	tags: ['experiment'],
+	render: () => <YourComponent />
+}
+```

--- a/libs/storybook/src/storybook-addon-tag-badges/experiment_badge.stories.tsx
+++ b/libs/storybook/src/storybook-addon-tag-badges/experiment_badge.stories.tsx
@@ -1,0 +1,29 @@
+import dedent from 'dedent'
+import { showSource, withStoryCard } from '#repobuddy/storybook'
+import type { Meta, StoryObj } from '#repobuddy/storybook/storybook-addon-tag-badges'
+
+export default {
+	title: 'storybook-addon-tag-badges/experimentBadge',
+	tags: ['var', '!snapshot', 'version:2.31'],
+	render: () => <></>
+} satisfies Meta
+
+export const ExperimentBadge: StoryObj = {
+	tags: ['experiment'],
+	decorators: [
+		withStoryCard({
+			content: (
+				<p>
+					Mark a component or prop as an early-stage experiment that may change significantly. In the sidebar it appears
+					as <code>🔬</code>.
+				</p>
+			)
+		}),
+		showSource({
+			source: dedent`export const YourStory = {
+				tags: ['experiment'],
+				render: () => <YourComponent />
+			}`
+		})
+	]
+}

--- a/libs/storybook/src/storybook-addon-tag-badges/tag_badges.ts
+++ b/libs/storybook/src/storybook-addon-tag-badges/tag_badges.ts
@@ -38,6 +38,7 @@ export type TagNames =
 	| 'alpha'
 	| 'beta'
 	| 'bug'
+	| 'experiment'
 	| 'rc'
 	| 'props'
 	| 'deprecated'
@@ -130,6 +131,19 @@ export const rcBadge: TagBadgeParameter = {
 			borderColor: 'transparent'
 		},
 		tooltip: 'Release Candidate'
+	}
+}
+
+/** Badge (🔬) for stories covering features in experiment. */
+export const experimentBadge: TagBadgeParameter = {
+	tags: 'experiment',
+	badge: {
+		text: '🔬',
+		style: {
+			backgroundColor: 'transparent',
+			borderColor: 'transparent'
+		},
+		tooltip: 'Experiment'
 	}
 }
 
@@ -542,11 +556,12 @@ export const perfBadge: TagBadgeParameter = {
  * Configuration for story tag badges that appear in the Storybook sidebar.
  * Each badge is associated with a specific tag and displays an emoji or symbol with a tooltip.
  *
- * Badge order (first match wins): New → Alpha → Beta → RC → Deprecated → Remove → Outdated → Danger → Bug → Use Case →
+ * Badge order (first match wins): New → Experiment → Alpha → Beta → RC → Deprecated → Remove → Outdated → Danger → Bug → Use Case →
  * Spec → Playground → Example → Perf → A11y → Keyboard → Source → Type → Class → Function → Var → Props → Todo → Unit →
  * Integration → Editor → Code Only → Version → Internal → Snapshot.
  *
  * - 🆕 New - Recently added stories
+ * - 🔬 Experiment - Stories for features in experiment
  * - 🔴 Alpha - Stories for features in alpha
  * - 🟡 Beta - Stories for features in beta
  * - 🔵 RC - Release candidate
@@ -582,7 +597,7 @@ export const tagBadges: TagBadgeParameters = [
 	// Story states
 	[bugBadge, todoBadge],
 	newBadge,
-	[alphaBadge, betaBadge, rcBadge],
+	[experimentBadge, alphaBadge, betaBadge, rcBadge],
 	[deprecatedBadge, removeBadge, outdatedBadge, dangerBadge],
 	useCaseBadge,
 	specBadge,

--- a/libs/storybook/src/storybook-addon-tag-badges/types.spec.ts
+++ b/libs/storybook/src/storybook-addon-tag-badges/types.spec.ts
@@ -9,6 +9,7 @@ it('improves StoryObj[tags]', () => {
 			'new',
 			'alpha',
 			'beta',
+			'experiment',
 			'rc',
 			'props',
 			'deprecated',


### PR DESCRIPTION
## Summary

- Add `experiment` tag and `experimentBadge` (🔬) to `storybook-addon-tag-badges`
- Badge is ordered before `alpha`/`beta`/`rc` to represent an earlier stage of feature maturity
- Includes story, MDX docs, type spec coverage, readme table entry, and changeset

## Test plan

- [ ] `experiment_badge.stories.tsx` renders correctly in Storybook with the 🔬 badge visible in the sidebar
- [ ] Adding `tags: ['experiment']` to any story shows the badge
- [ ] TypeScript accepts `'experiment'` as a valid `TagNames` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)